### PR TITLE
Capture windows application logs other than puppet

### DIFF
--- a/windows_support_script.ps1
+++ b/windows_support_script.ps1
@@ -101,7 +101,7 @@ Get-WmiObject -Query "SELECT * FROM win32_service where (name = 'puppet' or name
 
 Write-Host 'Exporting Puppet Agent Services Application Event Logs ...'
 
-Get-Eventlog -Source puppet -LogName Application -After $eventlog_date 2> ($output_directory + '/eventlog_application_puppet_errors.txt') | Format-List Index, Time, EntryType, Message *>> ($output_directory + '/eventlog_application_puppet.txt')
+Get-Eventlog -Source puppet -LogName Application -After $eventlog_date 2> ($output_directory + '/eventlog_application_puppet_errors.txt') | Format-List Index, TimeGenerated, EntryType, Message *>> ($output_directory + '/eventlog_application_puppet.txt')
 
 Write-Host 'Running Facter in Debug Mode ...'
 facter --debug --trace *>> ($output_directory + '/facter.log')

--- a/windows_support_script.ps1
+++ b/windows_support_script.ps1
@@ -103,6 +103,10 @@ Write-Host 'Exporting Puppet Agent Services Application Event Logs ...'
 
 Get-Eventlog -Source puppet -LogName Application -After $eventlog_date 2> ($output_directory + '/eventlog_application_puppet_errors.txt') | Format-List Index, TimeGenerated, EntryType, Message *>> ($output_directory + '/eventlog_application_puppet.txt')
 
+Write-Host 'Exporting Application Event Logs ...'
+
+Get-Eventlog -LogName Application -After $eventlog_date 2> ($output_directory + '/eventlog_application_errors.txt') | Format-List Index, TimeGenerated, EntryType, Message *>> ($output_directory + '/eventlog_application.txt')
+
 Write-Host 'Running Facter in Debug Mode ...'
 facter --debug --trace *>> ($output_directory + '/facter.log')
 


### PR DESCRIPTION
This PR updates the time field for the event logs to ensure that the output contains the timestamp and adds in the export of the full application logs.

The full application log export allows us to have context around what things are occurring on the host during and after the agent runs. For example, service starts, powershell script output, etc.